### PR TITLE
Add NewFromConfig to accept a pre-built aws.Config

### DIFF
--- a/ebsfile.go
+++ b/ebsfile.go
@@ -89,6 +89,11 @@ type File struct {
 	ctx       context.Context
 }
 
+// NewFromConfig creates a new EBS from an existing aws.Config.
+func NewFromConfig(cfg aws.Config, optFns ...func(*ebs.Options)) *EBS {
+	return &EBS{ebs.NewFromConfig(cfg, optFns...)}
+}
+
 func New(ctx context.Context, optFns ...func(*config.LoadOptions) error) (*EBS, error) {
 	cfg, err := config.LoadDefaultConfig(ctx, optFns...)
 	if err != nil {


### PR DESCRIPTION
## Summary

The existing `New()` always calls `config.LoadDefaultConfig()` internally, so callers cannot pass a pre-built `aws.Config`.

This PR adds `NewFromConfig(cfg aws.Config, optFns ...func(*ebs.Options)) *EBS` to allow injecting an externally constructed `aws.Config`, which is useful when using this library programmatically (e.g., calling Trivy as a library rather than a subprocess).

## Changes

- Add `NewFromConfig` function to `ebsfile.go`
  - Accepts `aws.Config` and optional `ebs.Options` functional options (following the AWS SDK v2 convention)
  - Returns `*EBS` directly (no error, since `ebs.NewFromConfig` doesn't return one)
- No changes to the existing `New()` — full backward compatibility

## Motivation

When using go-ebs-file as a library dependency (rather than via CLI), the caller may have already constructed an `aws.Config` with refreshed credentials. Currently, there is no way to pass it through — `New()` always creates a fresh config via `LoadDefaultConfig()`.

---

## 概要

既存の `New()` は内部で `config.LoadDefaultConfig()` を呼び出すため、呼び出し元から構築済みの `aws.Config` を渡す手段がありません。

このPRでは `NewFromConfig(cfg aws.Config, optFns ...func(*ebs.Options)) *EBS` を追加し、外部で構築した `aws.Config` を直接注入できるようにします。Trivyをライブラリとして呼び出すユースケース等で有用です。

## 変更内容

- `ebsfile.go` に `NewFromConfig` 関数を追加
  - `aws.Config` と省略可能な `ebs.Options` 関数オプションを受け取る（AWS SDK v2 の慣例に準拠）
  - `ebs.NewFromConfig` がエラーを返さないため、戻り値は `*EBS` のみ
- 既存の `New()` は変更なし（後方互換を維持）

## 動機

go-ebs-fileをライブラリとして利用する場合、呼び出し元でクレデンシャルを再取得した `aws.Config` を引き継がせたいケースがあります。現状の `New()` は常に `LoadDefaultConfig()` で新規にconfigを生成するため、これが実現できません。
