### PR TITLE
Fix ReadAt bugs and enhance MockEBS

### DIFF
--- a/ebsfile.go
+++ b/ebsfile.go
@@ -21,7 +21,7 @@ type MockEBS struct {
 	Reader     io.ReaderAt
 	BlockSize  *int32
 	NextToken  *string
-	VolumeSize *int64          // volume size in bytes (unlike the real EBS API which returns GiB)
+	VolumeSize *int64         // volume size in bytes (unlike the real EBS API which returns GiB)
 	Allocated  map[int32]bool // nil means all blocks are allocated
 	PageSize   int            // 0 means all blocks in a single page (no pagination)
 }

--- a/ebsfile.go
+++ b/ebsfile.go
@@ -13,37 +13,85 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ebs/types"
 )
 
+var _ EBSAPI = (*MockEBS)(nil)
+
 type MockEBS struct {
 	EBSAPI
 
-	f          *os.File
+	Reader     io.ReaderAt
 	BlockSize  *int32
 	NextToken  *string
-	VolumeSize *int64
+	VolumeSize *int64          // volume size in bytes (unlike the real EBS API which returns GiB)
+	Allocated  map[int32]bool // nil means all blocks are allocated
+	PageSize   int            // 0 means all blocks in a single page (no pagination)
 }
 
-func (m MockEBS) WalkSnapshotBlocks(_ context.Context, _ *ebs.ListSnapshotBlocksInput, _ map[int32]string) (*ebs.ListSnapshotBlocksOutput, map[int32]string, error) {
-	indexLen := *m.VolumeSize / int64(*m.BlockSize)
-	var blocks []types.Block
-	t := make(map[int32]string)
-	for i := int32(0); i < int32(indexLen); i++ {
-		blocks = append(blocks, types.Block{BlockIndex: aws.Int32(i)})
-		t[i] = ""
+func (m *MockEBS) ListSnapshotBlocks(_ context.Context, params *ebs.ListSnapshotBlocksInput, _ ...func(*ebs.Options)) (*ebs.ListSnapshotBlocksOutput, error) {
+	numBlocks := int32(*m.VolumeSize / int64(*m.BlockSize))
+
+	startIndex := int32(0)
+	if params.NextToken != nil {
+		if _, err := fmt.Sscanf(*params.NextToken, "token-%d", &startIndex); err != nil {
+			return nil, fmt.Errorf("invalid next token %q: %w", *params.NextToken, err)
+		}
 	}
 
-	return &ebs.ListSnapshotBlocksOutput{
+	pageSize := m.PageSize
+	if pageSize <= 0 {
+		pageSize = int(numBlocks)
+	}
+
+	var blocks []types.Block
+	count := 0
+	nextStart := int32(-1)
+	for i := startIndex; i < numBlocks; i++ {
+		if m.Allocated != nil && !m.Allocated[i] {
+			continue
+		}
+		if count >= pageSize {
+			nextStart = i
+			break
+		}
+		blocks = append(blocks, types.Block{
+			BlockIndex: aws.Int32(i),
+			BlockToken: aws.String(fmt.Sprintf("block-token-%d", i)),
+		})
+		count++
+	}
+
+	output := &ebs.ListSnapshotBlocksOutput{
 		Blocks:     blocks,
 		BlockSize:  m.BlockSize, // 512 KB
 		VolumeSize: m.VolumeSize,
-	}, t, nil
+	}
+	if nextStart >= 0 {
+		output.NextToken = aws.String(fmt.Sprintf("token-%d", nextStart))
+	}
+	return output, nil
 }
 
-func (m MockEBS) GetSnapshotBlock(_ context.Context, params *ebs.GetSnapshotBlockInput, optFns ...func(*ebs.Options)) (*ebs.GetSnapshotBlockOutput, error) {
+func (m *MockEBS) WalkSnapshotBlocks(ctx context.Context, input *ebs.ListSnapshotBlocksInput, table map[int32]string) (*ebs.ListSnapshotBlocksOutput, map[int32]string, error) {
+	output, err := m.ListSnapshotBlocks(ctx, input)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, block := range output.Blocks {
+		table[*block.BlockIndex] = *block.BlockToken
+	}
+	if output.NextToken != nil {
+		nextInput := *input
+		nextInput.NextToken = output.NextToken
+		return m.WalkSnapshotBlocks(ctx, &nextInput, table)
+	}
+	return output, table, nil
+}
+
+func (m *MockEBS) GetSnapshotBlock(_ context.Context, params *ebs.GetSnapshotBlockInput, _ ...func(*ebs.Options)) (*ebs.GetSnapshotBlockOutput, error) {
 	buf := make([]byte, *m.BlockSize)
 
-	offset := *params.BlockIndex * (*m.BlockSize)
-	n, err := m.f.ReadAt(buf, int64(offset))
-	if err != nil {
+	offset := int64(*params.BlockIndex) * int64(*m.BlockSize)
+	n, err := m.Reader.ReadAt(buf, offset)
+	if err != nil && err != io.EOF {
 		return nil, err
 	}
 	return &ebs.GetSnapshotBlockOutput{
@@ -58,11 +106,13 @@ func NewMockEBS(filePath string, blockSize int32, volumeSize int64) EBSAPI {
 		return nil
 	}
 	return &MockEBS{
-		f:          f,
+		Reader:     f,
 		BlockSize:  aws.Int32(blockSize),
 		VolumeSize: aws.Int64(volumeSize),
 	}
 }
+
+var _ EBSAPI = (*EBS)(nil)
 
 type EBS struct {
 	*ebs.Client

--- a/ebsfile.go
+++ b/ebsfile.go
@@ -140,34 +140,56 @@ func Open(snapID string, ctx context.Context, cache Cache[string, []byte], e EBS
 }
 
 func (f *File) ReadAt(p []byte, off int64) (n int, err error) {
-	index, dataOffset := f.translateOffset(off)
-	token, ok := f.blockTable[index]
-	if !ok {
-		if f.blockSize-dataOffset < int32(len(p)) {
-			return int(f.blockSize - dataOffset), nil
-		} else {
-			return len(p), nil
-		}
+	if off < 0 {
+		return 0, fmt.Errorf("ebsfile: negative offset %d", off)
+	}
+	if off >= f.size {
+		return 0, io.EOF
 	}
 
-	key := cacheKey(int64(index))
-	buf, ok := f.cache.Get(key)
-	if !ok {
-		buf, err = f.read(index, token)
-		if err != nil {
-			return 0, err
+	for n < len(p) && off+int64(n) < f.size {
+		index, dataOffset := f.translateOffset(off + int64(n))
+		readable := int(f.blockSize - dataOffset)
+		remaining := len(p) - n
+		if readable > remaining {
+			readable = remaining
 		}
-		f.cache.Add(key, buf)
-	}
-	if len(buf) != int(f.blockSize) {
-		return 0, fmt.Errorf("invalid block size: len(buf): %d != f.blockSize: %d", len(buf), f.blockSize)
+		if volRemaining := int(f.size - off - int64(n)); readable > volRemaining {
+			readable = volRemaining
+		}
+
+		token, ok := f.blockTable[index]
+		if !ok {
+			// Blocks not in blockTable are unallocated in the EBS snapshot,
+			// which represent zero-filled disk regions.
+			for i := 0; i < readable; i++ {
+				p[n+i] = 0
+			}
+			n += readable
+			continue
+		}
+
+		key := cacheKey(int64(index))
+		buf, ok := f.cache.Get(key)
+		if !ok {
+			buf, err = f.read(index, token)
+			if err != nil {
+				return n, err
+			}
+			f.cache.Add(key, buf)
+		}
+		if len(buf) != int(f.blockSize) {
+			return n, fmt.Errorf("invalid block size: len(buf): %d != f.blockSize: %d", len(buf), f.blockSize)
+		}
+
+		copied := copy(p[n:], buf[dataOffset:dataOffset+int32(readable)])
+		n += copied
 	}
 
-	if f.blockSize-dataOffset < int32(len(p)) {
-		return copy(p, buf[dataOffset:]), nil
-	} else {
-		return copy(p, buf[dataOffset:dataOffset+int32(len(p))]), nil
+	if n < len(p) {
+		return n, io.EOF
 	}
+	return n, nil
 }
 
 func (f *File) Size() int64 {
@@ -191,11 +213,12 @@ func (f *File) read(index int32, token string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer o.BlockData.Close()
+
 	buf, err := io.ReadAll(o.BlockData)
 	if err != nil {
 		return nil, err
 	}
-	defer o.BlockData.Close()
 
 	return buf, nil
 }

--- a/ebsfile_test.go
+++ b/ebsfile_test.go
@@ -1,0 +1,289 @@
+package ebsfile
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
+func TestWalkSnapshotBlocks_Pagination(t *testing.T) {
+	blockSize := int32(16)
+	numBlocks := int32(10)
+	volumeSize := int64(numBlocks) * int64(blockSize) // 160 bytes
+
+	data := make([]byte, volumeSize)
+	for i := int32(0); i < numBlocks; i++ {
+		data[int64(i)*int64(blockSize)] = byte(i)
+	}
+
+	mock := &MockEBS{
+		Reader:     bytes.NewReader(data),
+		BlockSize:  aws.Int32(blockSize),
+		VolumeSize: aws.Int64(volumeSize),
+		PageSize:   3, // 3 blocks per page → 4 pages for 10 blocks
+	}
+
+	sr, err := Open("snap-pagination", context.Background(), nil, mock)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if sr.Size() != volumeSize {
+		t.Fatalf("expected size %d, got %d", volumeSize, sr.Size())
+	}
+
+	// Read first byte of each block to verify all pages were collected
+	buf := make([]byte, 1)
+	for i := int32(0); i < numBlocks; i++ {
+		off := int64(i) * int64(blockSize)
+		n, err := sr.ReadAt(buf, off)
+		if err != nil {
+			t.Fatalf("block %d: unexpected error: %v", i, err)
+		}
+		if n != 1 || buf[0] != byte(i) {
+			t.Errorf("block %d: got n=%d, buf[0]=0x%02X, want 0x%02X", i, n, buf[0], byte(i))
+		}
+	}
+}
+
+func TestWalkSnapshotBlocks_PaginationWithUnallocated(t *testing.T) {
+	blockSize := int32(16)
+	numBlocks := int32(8)
+	volumeSize := int64(numBlocks) * int64(blockSize) // 128 bytes
+
+	data := make([]byte, volumeSize)
+	allocated := make(map[int32]bool)
+	// Allocate only even blocks
+	for i := int32(0); i < numBlocks; i++ {
+		if i%2 == 0 {
+			allocated[i] = true
+			data[int64(i)*int64(blockSize)] = 0xAA
+		}
+	}
+
+	mock := &MockEBS{
+		Reader:     bytes.NewReader(data),
+		BlockSize:  aws.Int32(blockSize),
+		VolumeSize: aws.Int64(volumeSize),
+		Allocated:  allocated,
+		PageSize:   2, // 2 blocks per page → multiple pages
+	}
+
+	sr, err := Open("snap-unalloc", context.Background(), nil, mock)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Allocated block 0: should have marker
+	buf := make([]byte, 1)
+	n, err := sr.ReadAt(buf, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 || buf[0] != 0xAA {
+		t.Errorf("block 0: got n=%d, buf[0]=0x%02X, want 0xAA", n, buf[0])
+	}
+
+	// Unallocated block 1: should be zero
+	buf[0] = 0xFF
+	n, err = sr.ReadAt(buf, int64(blockSize))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 || buf[0] != 0x00 {
+		t.Errorf("block 1: got n=%d, buf[0]=0x%02X, want 0x00", n, buf[0])
+	}
+}
+
+func TestReadAt_UnallocatedBlockZeroFill(t *testing.T) {
+	blockSize := int32(16)
+	volumeSize := int64(48) // 3 blocks
+
+	data := make([]byte, volumeSize)
+	// Fill allocated blocks with non-zero data
+	for i := 0; i < int(blockSize); i++ {
+		data[i] = 0xAA                  // block 0
+		data[int(blockSize)*2+i] = 0xBB // block 2
+	}
+
+	mock := &MockEBS{
+		Reader:     bytes.NewReader(data),
+		BlockSize:  aws.Int32(blockSize),
+		VolumeSize: aws.Int64(volumeSize),
+		Allocated:  map[int32]bool{0: true, 2: true}, // block 1 is unallocated
+	}
+
+	sr, err := Open("snap-test", context.Background(), nil, mock)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read from unallocated block 1: should be all zeros
+	buf := make([]byte, blockSize)
+	// Pre-fill with garbage to verify zero-fill
+	for i := 0; i < len(buf); i++ {
+		buf[i] = 0xFF
+	}
+	n, err := sr.ReadAt(buf, int64(blockSize))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != int(blockSize) {
+		t.Fatalf("expected n=%d, got %d", blockSize, n)
+	}
+	for i, b := range buf {
+		if b != 0 {
+			t.Errorf("buf[%d] = 0x%02X, want 0x00", i, b)
+		}
+	}
+}
+
+func TestReadAt_CrossBlockBoundary(t *testing.T) {
+	blockSize := int32(16)
+	volumeSize := int64(48) // 3 blocks
+
+	data := make([]byte, volumeSize)
+	// Fill with distinct patterns per block
+	for i := 0; i < int(blockSize); i++ {
+		data[i] = 0xAA
+		data[int(blockSize)+i] = 0xBB
+		data[int(blockSize)*2+i] = 0xCC
+	}
+
+	mock := &MockEBS{
+		Reader:     bytes.NewReader(data),
+		BlockSize:  aws.Int32(blockSize),
+		VolumeSize: aws.Int64(volumeSize),
+	}
+
+	sr, err := Open("snap-test", context.Background(), nil, mock)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read across block 0 and block 1 boundary
+	// Start at offset 8 (middle of block 0), read 16 bytes (spans into block 1)
+	buf := make([]byte, 16)
+	n, err := sr.ReadAt(buf, 8)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 16 {
+		t.Fatalf("expected n=16, got %d", n)
+	}
+	// First 8 bytes should be from block 0 (0xAA)
+	for i := 0; i < 8; i++ {
+		if buf[i] != 0xAA {
+			t.Errorf("buf[%d] = 0x%02X, want 0xAA", i, buf[i])
+		}
+	}
+	// Next 8 bytes should be from block 1 (0xBB)
+	for i := 8; i < 16; i++ {
+		if buf[i] != 0xBB {
+			t.Errorf("buf[%d] = 0x%02X, want 0xBB", i, buf[i])
+		}
+	}
+}
+
+func TestReadAt_CrossBlockBoundaryWithUnallocated(t *testing.T) {
+	blockSize := int32(16)
+	volumeSize := int64(48) // 3 blocks
+
+	data := make([]byte, volumeSize)
+	for i := 0; i < int(blockSize); i++ {
+		data[i] = 0xAA
+		data[int(blockSize)*2+i] = 0xCC
+	}
+
+	mock := &MockEBS{
+		Reader:     bytes.NewReader(data),
+		BlockSize:  aws.Int32(blockSize),
+		VolumeSize: aws.Int64(volumeSize),
+		Allocated:  map[int32]bool{0: true, 2: true}, // block 1 unallocated
+	}
+
+	sr, err := Open("snap-test", context.Background(), nil, mock)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read across block 0, unallocated block 1, and block 2
+	buf := make([]byte, 32)
+	for i := 0; i < len(buf); i++ {
+		buf[i] = 0xFF
+	}
+	n, err := sr.ReadAt(buf, 8) // offset 8 in block 0
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 32 {
+		t.Fatalf("expected n=32, got %d", n)
+	}
+	// [0..7]: block 0 tail (0xAA)
+	for i := 0; i < 8; i++ {
+		if buf[i] != 0xAA {
+			t.Errorf("buf[%d] = 0x%02X, want 0xAA", i, buf[i])
+		}
+	}
+	// [8..23]: unallocated block 1 (0x00)
+	for i := 8; i < 24; i++ {
+		if buf[i] != 0x00 {
+			t.Errorf("buf[%d] = 0x%02X, want 0x00", i, buf[i])
+		}
+	}
+	// [24..31]: block 2 head (0xCC)
+	for i := 24; i < 32; i++ {
+		if buf[i] != 0xCC {
+			t.Errorf("buf[%d] = 0x%02X, want 0xCC", i, buf[i])
+		}
+	}
+}
+
+func TestReadAt_EOF(t *testing.T) {
+	blockSize := int32(16)
+	volumeSize := int64(32) // 2 blocks
+
+	data := make([]byte, volumeSize)
+	for i := 0; i < len(data); i++ {
+		data[i] = 0xDD
+	}
+
+	mock := &MockEBS{
+		Reader:     bytes.NewReader(data),
+		BlockSize:  aws.Int32(blockSize),
+		VolumeSize: aws.Int64(volumeSize),
+	}
+
+	sr, err := Open("snap-test", context.Background(), nil, mock)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read beyond EOF: offset at volumeSize
+	buf := make([]byte, 8)
+	n, err := sr.ReadAt(buf, volumeSize)
+	if err != io.EOF {
+		t.Fatalf("expected io.EOF, got %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected n=0, got %d", n)
+	}
+
+	// Read that extends past EOF
+	buf = make([]byte, 24)
+	n, err = sr.ReadAt(buf, int64(blockSize))
+	if err != io.EOF {
+		t.Fatalf("expected io.EOF, got %v", err)
+	}
+	if n != int(blockSize) {
+		t.Fatalf("expected n=%d, got %d", blockSize, n)
+	}
+	for i := 0; i < int(blockSize); i++ {
+		if buf[i] != 0xDD {
+			t.Errorf("buf[%d] = 0x%02X, want 0xDD", i, buf[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fix three bugs in `ReadAt` and enhance `MockEBS` for better testing support.

## Changes

### Bug Fixes

1. **Missing zero-fill for unallocated blocks**
   Unallocated blocks (not in `blockTable`) were not zero-filled when read. The buffer `p` could contain stale data from the caller.

2. **ReadAt does not handle cross-block boundary reads**
   `ReadAt` only read from a single block, returning `nil` error when `n < len(p)`, violating the `io.ReaderAt` contract.

3. **BlockData resource leak in read()**
   `defer o.BlockData.Close()` was placed after `io.ReadAll`, causing `BlockData` to leak when `ReadAll` returned an error.

### MockEBS Enhancements

- Changed `f *os.File` to `Reader io.ReaderAt` for in-memory testing support
- Implemented `ListSnapshotBlocks` method with pagination support
- Added `Allocated` field to simulate unallocated blocks
- Added `PageSize` field to control pagination behavior
- Added compile-time interface compliance checks (`var _ EBSAPI = (*MockEBS)(nil)`)

---

## 概要

`ReadAt` の3つのバグ修正と、`MockEBS` の機能強化を行います。

## 修正内容

### バグ修正

1. **未割り当てブロックのゼロ埋め漏れ**
   `blockTable` に存在しないブロック（未割り当て）を読み取る際、バッファをゼロ埋めせずバイト数だけ返していた。呼び出し元バッファにゴミデータが残る可能性があった。

2. **ブロック境界をまたぐ読み取りの未対応**
   `ReadAt` は単一ブロックからしか読み取らず、`n < len(p)` で `nil` error を返していた。これは `io.ReaderAt` のインターフェース契約に違反する。

3. **`BlockData` のリソースリーク**
   `read()` メソッドで `defer o.BlockData.Close()` が `io.ReadAll` の後に配置されており、`ReadAll` がエラーを返した場合に `BlockData` がクローズされなかった。

### MockEBS の機能強化

- `f *os.File` → `Reader io.ReaderAt` に変更し、インメモリデータでのテストをサポート
- `ListSnapshotBlocks` メソッドを実装（ページネーション対応）
- `Allocated` フィールドで未割り当てブロックのシミュレーションをサポート
- `PageSize` フィールドでページネーションの制御が可能に
- コンパイル時のインターフェース準拠チェック (`var _ EBSAPI = (*MockEBS)(nil)`) を追加